### PR TITLE
Required argvs

### DIFF
--- a/bin/module-graph.js
+++ b/bin/module-graph.js
@@ -9,6 +9,7 @@ var cli = require('../dist/cli');
 cli(require('nomnom')
     .options({
         path: {
+            required: true,
             position: 0,
             help: 'Files or folders to read',
             list: true
@@ -19,6 +20,7 @@ cli(require('nomnom')
             default: false
         },
         output: {
+            required: true,
             abbr: 'o',
             metavar: 'FILE',
             help: 'Output JSON file'


### PR DESCRIPTION
Mark `paths` and `--output` as required CLI arguments. This way, when the user runs `$ module-graph` without any arguments, they get the help message.
